### PR TITLE
fix: handle corrupted JSONL lines in session loader

### DIFF
--- a/src/core/session.py
+++ b/src/core/session.py
@@ -168,7 +168,10 @@ class SessionStore:
                 line = line.strip()
                 if not line:
                     continue
-                obj = json.loads(line)
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
                 obj.pop("_ts", None)
                 messages.append(obj)
         return messages


### PR DESCRIPTION
When a session JSONL file contains corrupted lines, `json.loads()` raises  `JSONDecodeError` and crashes the entire session loader. This patch catches  the exception and skips malformed lines, preserving all valid messages.  